### PR TITLE
Added support for generic_usernames

### DIFF
--- a/gambit/algorithms/bird.py
+++ b/gambit/algorithms/bird.py
@@ -136,7 +136,7 @@ def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=['git','g
 # -------------------------------------------------------------------
 
 
-def bird(authors, thresh=.95):
+def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)
@@ -155,7 +155,7 @@ def bird(authors, thresh=.95):
                 next_id += 1
 
             for idx2, row2 in authors[idx1+1:].iterrows():
-                if compare_rows(idx1, idx2, row1, row2, thresh=thresh):
+                if compare_rows(idx1, idx2, row1, row2, thresh=thresh, generic_usernames=generic_usernames):
                     if pd.notnull(authors.loc[idx1, 'author_id']) and pd.notnull(authors.loc[idx2, 'author_id']):
                         min_id = min(authors.loc[idx1, 'author_id'], authors.loc[idx2, 'author_id'])
                         authors.loc[authors.author_id == authors.loc[idx1, 'author_id'], 'author_id'] = min_id

--- a/gambit/algorithms/bird.py
+++ b/gambit/algorithms/bird.py
@@ -70,7 +70,7 @@ def lev_sim(s1, s2):
     return 1 - lev_dist(s1, s2)/max(len(s1), len(s2))
 
 
-def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=[]):
     name_thresh = 2
     email_thresh = 3
 
@@ -136,7 +136,7 @@ def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=['git','g
 # -------------------------------------------------------------------
 
 
-def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
+def bird(authors, thresh=.95, generic_usernames=[], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)

--- a/gambit/algorithms/bird.py
+++ b/gambit/algorithms/bird.py
@@ -136,7 +136,7 @@ def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=['git','g
 # -------------------------------------------------------------------
 
 
-def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)
@@ -148,7 +148,7 @@ def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','
     authors['author_id'] = None
     next_id = 0
 
-    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation') as pbar:
+    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', disable=not show_pbar) as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
                 authors.loc[idx1,'author_id'] = next_id

--- a/gambit/algorithms/bird.py
+++ b/gambit/algorithms/bird.py
@@ -70,7 +70,7 @@ def lev_sim(s1, s2):
     return 1 - lev_dist(s1, s2)/max(len(s1), len(s2))
 
 
-def compare_rows(idx1, idx2, row1, row2, thresh=.90):
+def compare_rows(idx1, idx2, row1, row2, thresh=.90, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     name_thresh = 2
     email_thresh = 3
 
@@ -102,8 +102,8 @@ def compare_rows(idx1, idx2, row1, row2, thresh=.90):
         )
 
     # comparing email base leads to many false positives e.g. with emails following first_name@last_name
-    if (email_base1 and len(email_base1) >= email_thresh) and \
-       (email_base2 and len(email_base2) >= email_thresh):
+    if (email_base1 and len(email_base1) >= email_thresh and email_base1 not in generic_usernames) and \
+       (email_base2 and len(email_base2) >= email_thresh and email_base2 not in generic_usernames):
         sims.append(2*(email1 == email2))
         sims.append(sim_f(email_base1, email_base2))
 
@@ -111,8 +111,8 @@ def compare_rows(idx1, idx2, row1, row2, thresh=.90):
        (last_name1 and len(last_name1) >= name_thresh) and \
        (first_name2 and len(first_name2) >= name_thresh) and \
        (last_name2 and len(last_name2) >= name_thresh) and \
-       (email_base1 and len(email_base1) >= email_thresh) and \
-       (email_base2 and len(email_base2) >= email_thresh):
+       (email_base1 and len(email_base1) >= email_thresh and email_base1 not in generic_usernames) and \
+       (email_base2 and len(email_base2) >= email_thresh and email_base2 not in generic_usernames):
         if first_name2 != last_name2:
             sims.append(email_base1.find(first_name2[0] + last_name2) != -1)
             sims.append(email_base1.find(first_name2 + last_name2[0]) != -1)

--- a/gambit/algorithms/bird.py
+++ b/gambit/algorithms/bird.py
@@ -151,7 +151,7 @@ def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','
     with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation') as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
-                authors['author_id'][idx1] = next_id
+                authors.loc[idx1,'author_id'] = next_id
                 next_id += 1
 
             for idx2, row2 in authors[idx1+1:].iterrows():
@@ -161,7 +161,7 @@ def bird(authors, thresh=.95, generic_usernames=['git','github','root','admin','
                         authors.loc[authors.author_id == authors.loc[idx1, 'author_id'], 'author_id'] = min_id
                         authors.loc[authors.author_id == authors.loc[idx2, 'author_id'], 'author_id'] = min_id
                     elif pd.notnull(authors.loc[idx1, 'author_id']):
-                        authors['author_id'][idx2] = authors.loc[idx1, 'author_id']
+                        authors.loc[idx2,'author_id'] = authors.loc[idx1, 'author_id']
                     else:
                         assert False
                 pbar.update(1)

--- a/gambit/algorithms/gambit.py
+++ b/gambit/algorithms/gambit.py
@@ -125,7 +125,7 @@ def lev_sim(s1, s2):
     return 1 - lev_dist(s1, s2)/max(len(s1), len(s2))
 
 
-def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_usernames=[]):
     name_thresh = 3
     email_thresh = 3
 
@@ -242,7 +242,7 @@ def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_
 # -------------------------------------------------------------------
 
 
-def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
+def gambit(authors, thresh=0.95, sim='lev', generic_usernames=[], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)

--- a/gambit/algorithms/gambit.py
+++ b/gambit/algorithms/gambit.py
@@ -242,7 +242,7 @@ def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_
 # -------------------------------------------------------------------
 
 
-def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)
@@ -255,7 +255,7 @@ def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','r
     authors['author_id'] = None
     next_id = 0
 
-    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation') as pbar:
+    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', diable=not show_pbar) as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
                 authors.loc[idx1, 'author_id'] = next_id

--- a/gambit/algorithms/gambit.py
+++ b/gambit/algorithms/gambit.py
@@ -125,7 +125,7 @@ def lev_sim(s1, s2):
     return 1 - lev_dist(s1, s2)/max(len(s1), len(s2))
 
 
-def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw'):
+def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     name_thresh = 3
     email_thresh = 3
 
@@ -205,8 +205,8 @@ def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw'):
                             sim_f(last_name1, first_name2)))
 
     # comparing email base leads to many false positives e.g. with emails following first_name@last_name
-    if (email_base1 and len(email_base1) >= email_thresh) and \
-       (email_base2 and len(email_base2) >= email_thresh):
+    if (email_base1 and len(email_base1) >= email_thresh and email_base1 not in generic_usernames) and \
+       (email_base2 and len(email_base2) >= email_thresh and email_base2 not in generic_usernames):
         sims.append(2*(email1 == email2))
         sims.append(sim_f(email_base1, email_base2))
 
@@ -214,8 +214,8 @@ def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw'):
        (last_name1 and len(last_name1) >= name_thresh) and \
        (first_name2 and len(first_name2) >= name_thresh) and \
        (last_name2 and len(last_name2) >= name_thresh) and \
-       (email_base1 and len(email_base1) >= email_thresh) and \
-       (email_base2 and len(email_base2) >= email_thresh):
+       (email_base1 and len(email_base1) >= email_thresh and email_base1 not in generic_usernames) and \
+       (email_base2 and len(email_base2) >= email_thresh and email_base2 not in generic_usernames):
         if first_name2 != last_name2:
             sims.append(email_base1.find(first_name2[0] + last_name2) != -1)
 

--- a/gambit/algorithms/gambit.py
+++ b/gambit/algorithms/gambit.py
@@ -255,7 +255,7 @@ def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','r
     authors['author_id'] = None
     next_id = 0
 
-    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', diable=not show_pbar) as pbar:
+    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', disable=not show_pbar) as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
                 authors.loc[idx1, 'author_id'] = next_id

--- a/gambit/algorithms/gambit.py
+++ b/gambit/algorithms/gambit.py
@@ -242,7 +242,7 @@ def compare_rows(idx1, idx2, row1, row2, authors, thresh=.90, sim='jw', generic_
 # -------------------------------------------------------------------
 
 
-def gambit(authors, thresh=0.95, sim='lev'):
+def gambit(authors, thresh=0.95, sim='lev', generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name'].apply(clean_name)
@@ -262,7 +262,7 @@ def gambit(authors, thresh=0.95, sim='lev'):
                 next_id += 1
 
             for idx2, row2 in authors[idx1+1:].iterrows():
-                if compare_rows(idx1, idx2, row1, row2, authors, thresh=thresh, sim=sim):
+                if compare_rows(idx1, idx2, row1, row2, authors, thresh=thresh, sim=sim, generic_usernames=generic_usernames):
                     if pd.notnull(authors.loc[idx1, 'author_id']) and pd.notnull(authors.loc[idx2, 'author_id']):
                         min_id = min(authors.loc[idx1, 'author_id'], authors.loc[idx2, 'author_id'])
                         authors.loc[authors.author_id == authors.loc[idx1, 'author_id'], 'author_id'] = min_id

--- a/gambit/algorithms/simple.py
+++ b/gambit/algorithms/simple.py
@@ -40,7 +40,7 @@ def simple(authors, generic_usernames=['git','github','root','admin','administra
     with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation') as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
-                authors['author_id'][idx1] = next_id
+                authors.loc[idx1,'author_id'] = next_id
                 next_id += 1
 
             for idx2, row2 in authors[idx1+1:].iterrows():
@@ -50,7 +50,7 @@ def simple(authors, generic_usernames=['git','github','root','admin','administra
                         authors.loc[authors.author_id == authors.loc[idx1, 'author_id'], 'author_id'] = min_id
                         authors.loc[authors.author_id == authors.loc[idx2, 'author_id'], 'author_id'] = min_id
                     elif pd.notnull(authors.loc[idx1, 'author_id']):
-                        authors['author_id'][idx2] = authors.loc[idx1, 'author_id']
+                        authors.loc[idx2,'author_id'] = authors.loc[idx1, 'author_id']
                     else:
                         assert False
                 pbar.update(1)

--- a/gambit/algorithms/simple.py
+++ b/gambit/algorithms/simple.py
@@ -9,7 +9,7 @@ def get_email_base(s):
     return s
 
 
-def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
     tresh = 3
 
     if (len(str(row1.name)) >= tresh) and (len(str(row2.name)) >= tresh) and (row1.name == row2.name):
@@ -37,7 +37,7 @@ def simple(authors, generic_usernames=['git','github','root','admin','administra
     authors['author_id'] = None
     next_id = 0
 
-    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation') as pbar:
+    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', diasble=not show_pbar) as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
                 authors.loc[idx1,'author_id'] = next_id

--- a/gambit/algorithms/simple.py
+++ b/gambit/algorithms/simple.py
@@ -9,13 +9,15 @@ def get_email_base(s):
     return s
 
 
-def compare_rows(idx1, idx2, row1, row2):
+def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     tresh = 3
 
     if (len(str(row1.name)) >= tresh) and (len(str(row2.name)) >= tresh) and (row1.name == row2.name):
         return True
     elif (len(str(row1.email_base)) >= tresh) and \
          (len(str(row2.email_base)) >= tresh) and \
+         (str(row1.email_base) not in generic_usernames) and \
+         (str(row2.email_base) not in generic_usernames) and \
          (row1.email_base == row2.email_base):
         return True
     else:
@@ -25,7 +27,7 @@ def compare_rows(idx1, idx2, row1, row2):
 # -------------------------------------------------------------------
 
 
-def simple(authors):
+def simple(authors, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name']
@@ -42,7 +44,7 @@ def simple(authors):
                 next_id += 1
 
             for idx2, row2 in authors[idx1+1:].iterrows():
-                if compare_rows(idx1, idx2, row1, row2):
+                if compare_rows(idx1, idx2, row1, row2, generic_usernames=generic_usernames):
                     if pd.notnull(authors.loc[idx1, 'author_id']) and pd.notnull(authors.loc[idx2, 'author_id']):
                         min_id = min(authors.loc[idx1, 'author_id'], authors.loc[idx2, 'author_id'])
                         authors.loc[authors.author_id == authors.loc[idx1, 'author_id'], 'author_id'] = min_id

--- a/gambit/algorithms/simple.py
+++ b/gambit/algorithms/simple.py
@@ -9,7 +9,7 @@ def get_email_base(s):
     return s
 
 
-def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
+def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
     tresh = 3
 
     if (len(str(row1.name)) >= tresh) and (len(str(row2.name)) >= tresh) and (row1.name == row2.name):
@@ -27,7 +27,7 @@ def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root
 # -------------------------------------------------------------------
 
 
-def simple(authors, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def simple(authors, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name']
@@ -37,7 +37,7 @@ def simple(authors, generic_usernames=['git','github','root','admin','administra
     authors['author_id'] = None
     next_id = 0
 
-    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', diasble=not show_pbar) as pbar:
+    with tqdm.tqdm(total=int(len(authors)*(len(authors)-1)/2), desc='author identity disambiguation', disable=not show_pbar) as pbar:
         for idx1, row1 in authors.iterrows():
             if pd.isnull(authors.loc[idx1, 'author_id']):
                 authors.loc[idx1,'author_id'] = next_id

--- a/gambit/algorithms/simple.py
+++ b/gambit/algorithms/simple.py
@@ -9,7 +9,7 @@ def get_email_base(s):
     return s
 
 
-def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous']):
+def compare_rows(idx1, idx2, row1, row2, generic_usernames=[]):
     tresh = 3
 
     if (len(str(row1.name)) >= tresh) and (len(str(row2.name)) >= tresh) and (row1.name == row2.name):
@@ -27,7 +27,7 @@ def compare_rows(idx1, idx2, row1, row2, generic_usernames=['git','github','root
 # -------------------------------------------------------------------
 
 
-def simple(authors, generic_usernames=['git','github','root','admin','administrator','system','test','guest','anonymous'], show_pbar=True):
+def simple(authors, generic_usernames=[], show_pbar=True):
     authors.reset_index(inplace=True, drop=True)
 
     authors['name'] = authors['alias_name']

--- a/gambit/main.py
+++ b/gambit/main.py
@@ -34,4 +34,7 @@ def disambiguate_aliases(aliases, method='gambit', **quargs):
     else:
         raise Exception('invalid method')
 
+    if 'generic_usernames' not in quargs:
+        quargs['generic_usernames'] = ['git','github','root','admin','administrator','system','test','guest','anonymous']
+
     return disambig_fun(aliases, **quargs)


### PR DESCRIPTION
Hello Christoph,

I figured out that disambiguation might fail if the email address contains generic usernames (e.g. root@domain01.com, root@domain02.com, ... or git@domain91.com, git@domain92.com, ..).

As a workaround, I am proposing to pass common generic usernames as keyword arguments. These common usernames are not going to be included in the analysis.